### PR TITLE
Upgrade JTS from 1.16.1 to 1.19.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ targetCompatibility = 1.8
 
 dependencies {
     compile 'de.topobyte:jgs:0.0.1'
-    compile 'org.locationtech.jts:jts-core:1.16.1'
+    compile 'org.locationtech.jts:jts-core:1.19.0'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {


### PR DESCRIPTION
I am trying to use this library in a project of mine that uses a newer build of the JTS binaries. However, doing so causes an exception to be thrown at runtime:
`java.lang.NoSuchMethodError: 'org.locationtech.jts.geom.LineString org.locationtech.jts.geom.Polygon.getExteriorRing()'`

This is because the signature of `org.locationtech.jts.geom.Polygon.getExteriorRing()` has changed between versions of JTS: in newer versions of the library, this method returns a `LinearRing` rather than a `LineString`.

Fortunately, `LinearRing` inherits from `LineString`, so no actual code changes are necessary - all that is needed is to recompile this library with the newer JTS dependency.

I thought I would suggest this change to the parent repo, as it may help others that experience the same problem in the future.